### PR TITLE
Prevent assertion failures when closing a socket and calling pauseRecv()

### DIFF
--- a/src/raw.cc
+++ b/src/raw.cc
@@ -517,7 +517,7 @@ NAN_METHOD(SocketWrap::Pause) {
 	int events = (pause_recv ? 0 : UV_READABLE)
 			| (pause_send ? 0 : UV_WRITABLE);
 
-	if (! socket->deconstructing_) {
+	if (! socket->deconstructing_ && socket->poll_initialised_) {
 		uv_poll_stop (socket->poll_watcher_);
 		if (events)
 			uv_poll_start (socket->poll_watcher_, events, IoEvent);


### PR DESCRIPTION
This should prevent
```
Assertion failed: !uv__is_closing(handle) (../deps/uv/src/unix/poll.c: uv_poll_stop: 112)
```
Which happens when closing socket and calling `pauseRecv`

Example in `net-ping` when calling `session.close()` with pending requests.

```.js
Session.prototype.close = function () {
	if (this.socket)
		this.socket.close ();
	this.flush (new Error ("Socket forcibly closed"));
	delete this.socket;
	return this;
};

Session.prototype.flush = function (error) {
	for (id in this.reqs) {
		var req = this.reqRemove (id);
		var sent = req.sent ? req.sent : new Date ();
		req.callback (error, req.target, sent, new Date ());
	}
};

Session.prototype.reqRemove = function (id) {
	var req = this.reqs[id];
	if (req) {
		clearTimeout (req.timer);
		delete req.timer;
		delete this.reqs[req.id];
		this.reqsPending--;
		console.log('Pending requests', this.reqsPending);
	}
	// If we have no more outstanding requests pause readable events
	if (this.reqsPending <= 0)
		if (! this.getSocket ().recvPaused)
			this.getSocket ().pauseRecv ();
	return req;
};
``` 