### PR TITLE
unprivileged icmp under linux

### DIFF
--- a/src/raw.cc
+++ b/src/raw.cc
@@ -305,7 +305,7 @@ int SocketWrap::CreateSocket (void) {
 	
 	this->poll_fd_ = socket (this->family_, SOCK_RAW, this->protocol_);
 	
-#ifdef __APPLE__
+#if defined (__APPLE__) || defined(__linux__)
 	/**
 	 ** On MAC OS X platforms for non-privileged users wishing to utilise ICMP
 	 ** a SOCK_DGRAM will be enough, so try to create this type of socket in


### PR DESCRIPTION
added check for __linux__ for creating SOCK_DGRAM with IPICMP_PROTO

This patch enables a user to create an unprivileged icmp socket under linux.

Fun fact: linux supports non-privileged users to create icmp sockets too since at least kernel 3.11.
Up until recently, use was constrained by the kernel parameter net.ipv4.ping_group_range. If one of the user's gids fell inside that range then a sock_dgram icmp socket can be created, otherwise it fails and errno is set to permission denied.  
The capability therefore has existed for quite some time, and was site configurable by root. 

Linux distributions have begun to set net.ipv4.ping_group_range to its maximum value, opening up usage for unprivileged icmp socket creation by default. Fedora switched in version 31 I believe, and Ubuntu was 20.04 if I'm not mistaken. 
  
Now, the caveat is this: a user can kick an icmp packet over the fence, but the kernel will intercept it and overwrite the id field in the icmp header and then recalculate the checksum. The newer version of ping in the linux iputils package overcomes this by setting 16 bytes of timestamp data (from the timeval struct, so seconds and microseconds) in the icmp payload and using those bytes for comparison when matching up echo replies. 
 